### PR TITLE
Keyboard works on firefox in addition to chrome

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -240,7 +240,7 @@ var Game = new (function() {
     $(document).on(Utils.touchEnd(), 'html', touchEnd);
 
     function keyPress(event) {
-      var key = String.fromCharCode(event.keyCode).toLowerCase(),
+      var key = String.fromCharCode(event.keyCode || event.charCode).toLowerCase(),
           nr = keyToNr[key] * 1;
       if (!tapToStart && nr > 0) {
         if (scaleBorder)


### PR DESCRIPTION
Firefox uses `event.charCode` instead of `event.keyCode` to get the key pressed.